### PR TITLE
Add NO_SNAKE define to exclude from build

### DIFF
--- a/src/MatrixSnake.cpp
+++ b/src/MatrixSnake.cpp
@@ -30,7 +30,7 @@
  */
 
 #include <Arduino.h>
-
+#ifndef NO_SNAKE
 // Output information on Serial must be defined before #include "MatrixSnake.h"
 //#define TRACE
 //#define DEBUG
@@ -1017,4 +1017,4 @@ void MatrixAndSnakePatternsDemoHandler(NeoPatterns * aLedsPtr) {
 
     sState++;
 }
-
+#endif

--- a/src/MatrixSnake.h
+++ b/src/MatrixSnake.h
@@ -33,6 +33,7 @@
 
 #ifndef MATRIXSNAKE_H_
 #define MATRIXSNAKE_H_
+#ifndef NO_SNAKE
 
 #include "MatrixNeoPatterns.h"
 
@@ -140,6 +141,6 @@ uint8_t getNextSnakeDirection(MatrixSnake * aSnake);
 void SnakeAutorunCompleteHandler(NeoPatterns * aLedsPtr);
 
 #endif /* MATRIXSNAKE_H_ */
-
+#endif
 #pragma once
 


### PR DESCRIPTION
The MatrixSnake does not compile on ESP8266 (and others), due to EEMEM, as it is not always needed, I added a compile-time define NO_SNAKE